### PR TITLE
NEW Allow install in non-dev modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Tools to help developers building new applications on SilverStripe’s GraphQL A
 
 ## Installation
 ```
-$ composer require silverstripe/graphql-devtools
+$ composer require --dev silverstripe/graphql-devtools
 ```
 
 ## Requirements
@@ -14,7 +14,14 @@ $ composer require silverstripe/graphql-devtools
 
 This module adds an implementation of [graphiql](https://github.com/graphql/graphiql), an in-browser IDE for GraphQL servers. It provides browseable documentation of your schema, as well as autocomplete and syntax-checking of your queries.
  
- This tool is available in **dev mode only**. It can be accessed at `/dev/graphiql/`.
+It can be accessed at `/dev/graphiql/`.
+
+By default, the tool has the same restrictions as other development tools like `dev/build`:
+
+ * In "dev" mode, it's available without authentication
+ * In "test" and "live" mode, it requires ADMIN permissions
+ * It's installed with `composer require --dev` by default. In most deployment contexts that'll mean it's not available on environments in "test" or "live" modes
+
  
  <img src="https://github.com/graphql/graphiql/raw/master/resources/graphiql.png">
  

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,7 +1,5 @@
 ---
 Name: graphql-devtool-routes
-only:
-  environment: 'dev'
 ---
 SilverStripe\Dev\DevelopmentAdmin:
   registered_controllers:

--- a/src/GraphiQLController.php
+++ b/src/GraphiQLController.php
@@ -18,16 +18,12 @@ class GraphiQLController extends BaseController
     protected $template = 'GraphiQL';
 
     /**
-     * Initialise the controller, sanity check, load javascript
+     * Initialise the controller, sanity check, load javascript.
+     * Note that permission checks are handled by DevelopmentAdmin.
      */
     public function init()
     {
         parent::init();
-
-        if (!Director::isDev()) {
-            $this->httpError(403, 'The GraphiQL tool is only available in dev mode');
-            return;
-        }
 
         $routes = $this->findAvailableRoutes();
         $route = $this->getRequest()->getVar('endpoint') ?: $this->config()->default_route;


### PR DESCRIPTION
While this is a dev tool, it's also a good way to allow developers to play with a GraphQL API in a SilverStripe demo environment.
This environment should not run in dev mode, but rather enforce specific access control for this controller.

I've changed the default installation instructions to "require --dev", which should provide a first line of defence.
Developers installing this tool need to opt-in to making it available outside of dev contexts (assuming they're using composer properly).

The next level of defence is permission checks, rather than hard wiring the tool to only work in dev mode.
These checks are enforced by the DevelopmentAdmin parent controller.

The side effect of this is that every GraphQL request in non-dev mode will carry a session, making it harder to simulate
unauthenticated GraphQL responses. I don't think that's a problem in the module as such, but rather a shortcoming in how we've set up GraphQL.
It should use OAuth, JWT or API keys, and allow setting those through GraphiQL.
Given that it's a non issue in dev mode, I'm fine with that change.

Aside: Nesting controllers and relying on access control in parent controllers is a bit dangerous.
You could hook this controller to a different route, and accidentally run it without these checks.
That's not a problem specific to this module though.

Fixes https://github.com/silverstripe/silverstripe-graphql-devtools/issues/6