### PR TITLE
BUGFIX: remove enable_csrf_protection conditional for SecurityID

### DIFF
--- a/src/GraphiQLController.php
+++ b/src/GraphiQLController.php
@@ -40,9 +40,8 @@ class GraphiQLController extends BaseController
 
         $route = trim($route, '/');
         $jsonRoutes = json_encode($routes);
-        $securityID = Controller::config()->enable_csrf_protection
-            ? "'" . SecurityToken::inst()->getValue() . "'"
-            : 'null';
+        $securityID = "'" . SecurityToken::inst()->getValue() . "'";
+        
         Requirements::customScript(
             <<<JS
 var GRAPHQL_ROUTE = '{$route}';


### PR DESCRIPTION
This property doesn't exist anymore. It was replaced with middleware. I can't see any reason why you wouldn't want to send the X-SECURITYID header in all cases, whether it's enabled or not? After all, this is just a dev tool. 🤷‍♂️