### PR TITLE
Remove trailing slash from exposed path to correctly support symlink type of vendor-expose

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 	  "dev-master": "1.x-dev"
     },
     "expose": [
-        "client/"
+        "client"
     ]
   },
   "config": {


### PR DESCRIPTION
With the trailing slash, the method silently fails and defaults to the copy strategy which prevents dynamic updates to exposed assets from other modules.