### PR TITLE
Fix viewport dimensions

### DIFF
--- a/templates/DevTools.ss
+++ b/templates/DevTools.ss
@@ -7,15 +7,20 @@
     <title>GraphQL IDE | Silverstripe CMS</title>
     <link rel="shortcut icon" href="$resourceURL('silverstripe/graphql-devtools: client/favicon.png')" />
     <% require javascript('silverstripe/graphql-devtools: client/bundle.js') %>
+    
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+            overflow: hidden;
+        }
+    </style>
 </head>
 
 <body>
 <div id="root">
     <style>
         body {
-            margin: 0;
-            padding: 0;
-            overflow: hidden;
             font-family: 'Open Sans', sans-serif;
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
Place html, body style in the head block - the current style declaration in `#root` gets replaced by `ReactDOM.render()` and this results in default margins, paddings and scrollbars being applied to the document.

Before:
![image](https://user-images.githubusercontent.com/1631737/125561233-f1af3564-27a2-4f1c-888e-4a1a1fdef4f6.png)

After:
![image](https://user-images.githubusercontent.com/1631737/125561252-b4131d06-1dd2-4430-82cb-d856052cdea9.png)

