### PR TITLE
Revert "DEP Use PHPUnit 11"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "symfony/filesystem": "^4 || ^5 || ^6 || ^7"
     },
   "require-dev": {
-    "phpunit/phpunit": "^11.3",
+    "phpunit/phpunit": "^9.5",
     "silverstripe/framework": "^4.10",
     "squizlabs/php_codesniffer": "^3"
   },


### PR DESCRIPTION
Should have been done for the new CMS 6 branch only

This reverts commit 8ad509237199d978698a060e7626b91af4c9a7d1.

Fixes https://github.com/silverstripe/silverstripe-graphql-devtools/actions/runs/11002955994/job/30551286488
> Your requirements could not be resolved to an installable set of packages.

## Issue
- https://github.com/silverstripe/.github/issues/313